### PR TITLE
Data validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "data-dict",
+ "data-dict-parquet",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,35 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -84,16 +107,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -153,6 +221,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "data-dict"
 version = "0.0.1"
 dependencies = [
@@ -170,6 +270,13 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "data-dict",
+]
+
+[[package]]
+name = "data-dict-parquet"
+version = "0.0.1"
+dependencies = [
+ "parquet",
 ]
 
 [[package]]
@@ -227,6 +334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +361,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,9 +415,21 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -298,6 +470,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -433,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +668,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -481,6 +700,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,10 +784,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
+dependencies = [
+ "ahash",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -587,6 +918,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -654,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +1026,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -739,10 +1088,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -755,6 +1116,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -791,7 +1158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -818,6 +1185,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +1212,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]
@@ -870,6 +1267,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +1294,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -922,10 +1376,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1074,6 +1581,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,8 +256,10 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 name = "data-dict"
 version = "0.0.1"
 dependencies = [
+ "data-dict-parquet",
  "indexmap",
  "insta",
+ "parquet",
  "quarto-error-reporting",
  "quarto-source-map",
  "quarto-yaml",
@@ -271,6 +273,7 @@ dependencies = [
  "clap",
  "data-dict",
  "data-dict-parquet",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/data-dict", "crates/data-dict-cli"]
+members = ["crates/data-dict", "crates/data-dict-cli", "crates/data-dict-parquet"]
 
 [workspace.package]
 version = "0.0.1"
@@ -12,3 +12,5 @@ repository = "https://github.com/hadley/data-dict.yaml"
 data-dict = { path = "crates/data-dict", version = "0.0.1" }
 clap = { version = "4", features = ["derive"] }
 quarto-yaml-validation = { git = "https://github.com/quarto-dev/q2", branch = "main" }
+parquet = { version = "54", default-features = false }
+data-dict-parquet = { path = "crates/data-dict-parquet", version = "0.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ clap = { version = "4", features = ["derive"] }
 quarto-yaml-validation = { git = "https://github.com/quarto-dev/q2", branch = "main" }
 parquet = { version = "54", default-features = false }
 data-dict-parquet = { path = "crates/data-dict-parquet", version = "0.0.1" }
+serde_json = "1"

--- a/crates/data-dict-cli/Cargo.toml
+++ b/crates/data-dict-cli/Cargo.toml
@@ -12,4 +12,5 @@ path = "src/main.rs"
 
 [dependencies]
 data-dict.workspace = true
+data-dict-parquet.workspace = true
 clap.workspace = true

--- a/crates/data-dict-cli/Cargo.toml
+++ b/crates/data-dict-cli/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/main.rs"
 data-dict.workspace = true
 data-dict-parquet.workspace = true
 clap.workspace = true
+serde_json.workspace = true

--- a/crates/data-dict-cli/src/main.rs
+++ b/crates/data-dict-cli/src/main.rs
@@ -14,6 +14,17 @@ struct Cli {
 enum Command {
     /// Validate a data-dict.yaml file against the schema
     ValidateSchema { path: PathBuf },
+    /// Work with parquet files
+    Parquet {
+        #[command(subcommand)]
+        command: ParquetCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ParquetCommand {
+    /// Print column types for a parquet file
+    Types { path: PathBuf },
 }
 
 fn main() -> ExitCode {
@@ -29,5 +40,64 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Parquet {
+            command: ParquetCommand::Types { path },
+        } => match data_dict_parquet::column_type_info(&path) {
+            Ok(cols) => {
+                print_types_table(&cols);
+                ExitCode::SUCCESS
+            }
+            Err(err) => {
+                eprintln!("{err}");
+                ExitCode::FAILURE
+            }
+        },
+    }
+}
+
+fn print_types_table(cols: &[data_dict_parquet::ColumnTypeInfo]) {
+    let headers = ["#", "column", "dict type", "logical type", "physical type"];
+    let num_width = cols.len().to_string().len().max(headers[0].len());
+    let widths = [
+        num_width,
+        cols.iter().map(|c| c.name.len()).max().unwrap_or(0).max(headers[1].len()),
+        cols.iter().map(|c| c.dict_type.len()).max().unwrap_or(0).max(headers[2].len()),
+        cols.iter()
+            .map(|c| c.logical_type.as_deref().unwrap_or("").len())
+            .max()
+            .unwrap_or(0)
+            .max(headers[3].len()),
+        cols.iter().map(|c| c.physical_type.len()).max().unwrap_or(0).max(headers[4].len()),
+    ];
+
+    println!(
+        "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}",
+        headers[0],
+        headers[1],
+        headers[2],
+        headers[3],
+        headers[4],
+        w0 = widths[0],
+        w1 = widths[1],
+        w2 = widths[2],
+        w3 = widths[3],
+        w4 = widths[4],
+    );
+    println!("{}", "─".repeat(widths.iter().sum::<usize>() + 8));
+
+    for (i, col) in cols.iter().enumerate() {
+        println!(
+            "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}",
+            i + 1,
+            col.name,
+            col.dict_type,
+            col.logical_type.as_deref().unwrap_or(""),
+            col.physical_type,
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4],
+        );
     }
 }

--- a/crates/data-dict-cli/src/main.rs
+++ b/crates/data-dict-cli/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
+use data_dict::data::{ColumnIssue, DataError};
 
 #[derive(Parser)]
 #[command(name = "data-dict", version, about)]
@@ -25,6 +26,16 @@ enum Command {
 enum ParquetCommand {
     /// Print column types for a parquet file
     Types { path: PathBuf },
+    /// Validate a parquet file's columns against a data dictionary
+    Validate {
+        dict: PathBuf,
+        parquet: PathBuf,
+        #[arg(long)]
+        table: Option<String>,
+        /// Emit results as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 fn main() -> ExitCode {
@@ -52,6 +63,87 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Parquet {
+            command:
+                ParquetCommand::Validate {
+                    dict,
+                    parquet,
+                    table,
+                    json,
+                },
+        } => {
+            let result = data_dict::data::validate_parquet(&dict, &parquet, table.as_deref());
+            if json {
+                println!("{}", validate_result_to_json(&result));
+            }
+            match result {
+                Ok(()) => {
+                    if !json {
+                        println!("{}: ok", parquet.display());
+                    }
+                    ExitCode::SUCCESS
+                }
+                Err(err) => {
+                    if !json {
+                        eprintln!("{err}");
+                    }
+                    ExitCode::FAILURE
+                }
+            }
+        }
+    }
+}
+
+fn validate_result_to_json(result: &Result<(), DataError>) -> serde_json::Value {
+    match result {
+        Ok(()) => serde_json::json!({"status": "ok"}),
+        Err(DataError::Schema(e)) => serde_json::json!({
+            "status": "error",
+            "kind": "schema",
+            "message": e.to_string(),
+        }),
+        Err(DataError::Parquet(e)) => serde_json::json!({
+            "status": "error",
+            "kind": "parquet",
+            "message": e.to_string(),
+        }),
+        Err(DataError::TableNotFound { name, available }) => serde_json::json!({
+            "status": "error",
+            "kind": "table_not_found",
+            "name": name,
+            "available": available,
+        }),
+        Err(DataError::AmbiguousTable { available }) => serde_json::json!({
+            "status": "error",
+            "kind": "ambiguous_table",
+            "available": available,
+        }),
+        Err(DataError::Mismatch { table, issues }) => serde_json::json!({
+            "status": "error",
+            "kind": "mismatch",
+            "table": table,
+            "issues": issues.iter().map(issue_to_json).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn issue_to_json(issue: &ColumnIssue) -> serde_json::Value {
+    match issue {
+        ColumnIssue::TypeMismatch { column, declared, actual } => serde_json::json!({
+            "kind": "type_mismatch",
+            "column": column,
+            "declared": declared,
+            "actual": actual,
+        }),
+        ColumnIssue::MissingInData { column } => serde_json::json!({
+            "kind": "missing_in_data",
+            "column": column,
+        }),
+        ColumnIssue::ExtraInData { column, actual } => serde_json::json!({
+            "kind": "extra_in_data",
+            "column": column,
+            "actual": actual,
+        }),
     }
 }
 

--- a/crates/data-dict-parquet/Cargo.toml
+++ b/crates/data-dict-parquet/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "data-dict-parquet"
+description = "Parquet reader for data-dict.yaml validation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+parquet.workspace = true

--- a/crates/data-dict-parquet/src/lib.rs
+++ b/crates/data-dict-parquet/src/lib.rs
@@ -1,0 +1,51 @@
+//! Parquet reader for data-dict.yaml validation.
+
+use parquet::basic::{LogicalType, Type as PhysicalType};
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::schema::types::Type;
+use std::fs::File;
+use std::path::Path;
+
+/// Returns a list of `(column_name, data_dict_type)` pairs for all columns in a parquet file.
+///
+/// The data-dict types returned are: `"boolean"`, `"string"`, `"enum"`, `"date"`,
+/// `"datetime"`, and `"number"`.
+pub fn column_types(
+    path: &Path,
+) -> Result<Vec<(String, String)>, parquet::errors::ParquetError> {
+    let file = File::open(path).map_err(|e| {
+        parquet::errors::ParquetError::General(format!("Cannot open file: {e}"))
+    })?;
+    let reader = SerializedFileReader::new(file)?;
+    let schema = reader.metadata().file_metadata().schema();
+    let fields = schema.get_fields();
+    Ok(fields
+        .iter()
+        .map(|f| (f.name().to_string(), parquet_type_to_dict_type(f)))
+        .collect())
+}
+
+fn parquet_type_to_dict_type(field: &Type) -> String {
+    let info = field.get_basic_info();
+
+    if let Some(logical) = info.logical_type() {
+        match logical {
+            LogicalType::String => return "string".into(),
+            LogicalType::Enum => return "enum".into(),
+            LogicalType::Date => return "date".into(),
+            LogicalType::Timestamp { .. } => return "datetime".into(),
+            LogicalType::Integer { .. } | LogicalType::Float16 | LogicalType::Decimal { .. } => {
+                return "number".into()
+            }
+            _ => {}
+        }
+    }
+
+    match field.get_physical_type() {
+        PhysicalType::BOOLEAN => "boolean".into(),
+        PhysicalType::INT32 | PhysicalType::INT64 => "number".into(),
+        PhysicalType::INT96 => "datetime".into(),
+        PhysicalType::FLOAT | PhysicalType::DOUBLE => "number".into(),
+        PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => "string".into(),
+    }
+}

--- a/crates/data-dict-parquet/src/lib.rs
+++ b/crates/data-dict-parquet/src/lib.rs
@@ -1,10 +1,18 @@
 //! Parquet reader for data-dict.yaml validation.
 
-use parquet::basic::{LogicalType, Type as PhysicalType};
+use parquet::basic::{LogicalType, TimeUnit, Type as PhysicalType};
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::schema::types::Type;
 use std::fs::File;
 use std::path::Path;
+
+/// Type information for a single parquet column.
+pub struct ColumnTypeInfo {
+    pub name: String,
+    pub dict_type: String,
+    pub logical_type: Option<String>,
+    pub physical_type: String,
+}
 
 /// Returns a list of `(column_name, data_dict_type)` pairs for all columns in a parquet file.
 ///
@@ -23,6 +31,78 @@ pub fn column_types(
         .iter()
         .map(|f| (f.name().to_string(), parquet_type_to_dict_type(f)))
         .collect())
+}
+
+/// Returns type information for all columns in a parquet file, including dict type,
+/// parquet logical type, and parquet physical type.
+pub fn column_type_info(
+    path: &Path,
+) -> Result<Vec<ColumnTypeInfo>, parquet::errors::ParquetError> {
+    let file = File::open(path).map_err(|e| {
+        parquet::errors::ParquetError::General(format!("Cannot open file: {e}"))
+    })?;
+    let reader = SerializedFileReader::new(file)?;
+    let schema = reader.metadata().file_metadata().schema();
+    let fields = schema.get_fields();
+    Ok(fields
+        .iter()
+        .map(|f| {
+            let info = f.get_basic_info();
+            ColumnTypeInfo {
+                name: f.name().to_string(),
+                dict_type: parquet_type_to_dict_type(f),
+                logical_type: info.logical_type().map(format_logical_type),
+                physical_type: format!("{:?}", f.get_physical_type()),
+            }
+        })
+        .collect())
+}
+
+fn format_logical_type(lt: LogicalType) -> String {
+    match lt {
+        LogicalType::String => "String".into(),
+        LogicalType::Map => "Map".into(),
+        LogicalType::List => "List".into(),
+        LogicalType::Enum => "Enum".into(),
+        LogicalType::Decimal { precision, scale } => format!("Decimal({precision},{scale})"),
+        LogicalType::Date => "Date".into(),
+        LogicalType::Time {
+            is_adjusted_to_u_t_c,
+            unit,
+        } => {
+            let u = format_time_unit(unit);
+            let tz = if is_adjusted_to_u_t_c { "UTC" } else { "local" };
+            format!("Time({u},{tz})")
+        }
+        LogicalType::Timestamp {
+            is_adjusted_to_u_t_c,
+            unit,
+        } => {
+            let u = format_time_unit(unit);
+            let tz = if is_adjusted_to_u_t_c { "UTC" } else { "local" };
+            format!("Timestamp({u},{tz})")
+        }
+        LogicalType::Integer {
+            bit_width,
+            is_signed,
+        } => {
+            let sign = if is_signed { "i" } else { "u" };
+            format!("Integer({sign}{bit_width})")
+        }
+        LogicalType::Unknown => "Unknown".into(),
+        LogicalType::Json => "Json".into(),
+        LogicalType::Bson => "Bson".into(),
+        LogicalType::Uuid => "Uuid".into(),
+        LogicalType::Float16 => "Float16".into(),
+    }
+}
+
+fn format_time_unit(unit: TimeUnit) -> &'static str {
+    match unit {
+        TimeUnit::MILLIS(_) => "ms",
+        TimeUnit::MICROS(_) => "us",
+        TimeUnit::NANOS(_) => "ns",
+    }
 }
 
 fn parquet_type_to_dict_type(field: &Type) -> String {

--- a/crates/data-dict-parquet/src/lib.rs
+++ b/crates/data-dict-parquet/src/lib.rs
@@ -112,6 +112,10 @@ fn format_time_unit(unit: TimeUnit) -> &'static str {
 fn parquet_type_to_dict_type(field: &Type) -> String {
     let info = field.get_basic_info();
 
+    // Logical type takes precedence; physical type is the fallback.
+    // Unhandled logical types (Map, List, Time, Json, Bson, Uuid, Unknown) fall
+    // through — Time lands on "number" via INT32/INT64, the rest on "string".
+    // We'll handle nested types, at least List, later.
     if let Some(logical) = info.logical_type() {
         match logical {
             LogicalType::String => return "string".into(),

--- a/crates/data-dict-parquet/src/lib.rs
+++ b/crates/data-dict-parquet/src/lib.rs
@@ -6,6 +6,10 @@ use parquet::schema::types::Type;
 use std::fs::File;
 use std::path::Path;
 
+/// Re-export of the underlying parquet error type, so crates that consume
+/// [`column_types`] can name the error without depending on `parquet` directly.
+pub use parquet::errors::ParquetError;
+
 /// Type information for a single parquet column.
 pub struct ColumnTypeInfo {
     pub name: String,

--- a/crates/data-dict/Cargo.toml
+++ b/crates/data-dict/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+data-dict-parquet.workspace = true
 quarto-yaml-validation.workspace = true
 quarto-yaml = { git = "https://github.com/quarto-dev/q2", branch = "main" }
 quarto-source-map = { git = "https://github.com/quarto-dev/q2", branch = "main" }
@@ -15,3 +16,4 @@ indexmap = "2"
 
 [dev-dependencies]
 insta = "1"
+parquet.workspace = true

--- a/crates/data-dict/src/data.rs
+++ b/crates/data-dict/src/data.rs
@@ -199,14 +199,12 @@ pub fn validate_parquet(
     }
 }
 
-/// Collapse a declared dictionary type to its base form for comparison: any
-/// `number`/`number(...)` measure becomes `number`; everything else is
-/// returned unchanged.
+/// Collapse a declared dictionary type to its base form for comparison by
+/// dropping any trailing `(...)` qualifier.
 fn normalize_dict_type(dict_type: &str) -> &str {
-    if dict_type == "number" || dict_type.starts_with("number(") {
-        "number"
-    } else {
-        dict_type
+    match dict_type.find('(') {
+        Some(i) => &dict_type[..i],
+        None => dict_type,
     }
 }
 

--- a/crates/data-dict/src/data.rs
+++ b/crates/data-dict/src/data.rs
@@ -1,0 +1,254 @@
+//! Validate actual data against a data dictionary.
+//!
+//! Where [`crate::validate`] checks that a `data-dict.yaml` document is
+//! internally well-formed, this module checks that a *dataset* is consistent
+//! with the dictionary that describes it. Parquet is the first supported
+//! backend; more (SQL, R, …) are expected later.
+//!
+//! [`validate_parquet`] validates the dictionary, reads the parquet file's
+//! column types via [`data_dict_parquet::column_types`], and compares the two
+//! column-by-column.
+
+use std::path::Path;
+
+use data_dict_parquet::ParquetError;
+
+use crate::Error;
+
+/// A single way in which a dataset disagrees with its data dictionary.
+#[derive(Debug)]
+pub enum ColumnIssue {
+    /// A column present in both, but whose declared type is not compatible
+    /// with the type read from the data.
+    TypeMismatch {
+        column: String,
+        declared: String,
+        actual: String,
+    },
+    /// A column described by the dictionary that is absent from the data.
+    MissingInData { column: String },
+    /// A column in the data that the dictionary does not describe.
+    ExtraInData { column: String, actual: String },
+}
+
+/// Errors returned by [`validate_parquet`].
+#[derive(Debug)]
+pub enum DataError {
+    /// The dictionary itself failed schema/semantic validation.
+    Schema(Error),
+    /// The parquet file could not be read.
+    Parquet(ParquetError),
+    /// A table name was given but no such table exists in the dictionary.
+    TableNotFound {
+        name: String,
+        available: Vec<String>,
+    },
+    /// No table name was given and the dictionary describes more than one, so
+    /// the target is ambiguous.
+    AmbiguousTable { available: Vec<String> },
+    /// The dataset disagrees with the dictionary in one or more columns.
+    Mismatch {
+        table: String,
+        issues: Vec<ColumnIssue>,
+    },
+}
+
+impl From<Error> for DataError {
+    fn from(e: Error) -> Self {
+        DataError::Schema(e)
+    }
+}
+
+impl From<ParquetError> for DataError {
+    fn from(e: ParquetError) -> Self {
+        DataError::Parquet(e)
+    }
+}
+
+impl std::fmt::Display for DataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataError::Schema(e) => write!(f, "{e}"),
+            DataError::Parquet(e) => write!(f, "{e}"),
+            DataError::TableNotFound { name, available } => {
+                write!(
+                    f,
+                    "table \"{name}\" is not in the data dictionary (available: {})",
+                    available.join(", ")
+                )
+            }
+            DataError::AmbiguousTable { available } => {
+                write!(
+                    f,
+                    "the data dictionary describes multiple tables ({}); specify which one to validate against",
+                    available.join(", ")
+                )
+            }
+            DataError::Mismatch { table, issues } => {
+                writeln!(
+                    f,
+                    "data does not match table \"{table}\" in the data dictionary:"
+                )?;
+                for issue in issues {
+                    match issue {
+                        ColumnIssue::TypeMismatch {
+                            column,
+                            declared,
+                            actual,
+                        } => writeln!(
+                            f,
+                            "  column \"{column}\": declared {declared}, data is {actual}"
+                        )?,
+                        ColumnIssue::MissingInData { column } => writeln!(
+                            f,
+                            "  column \"{column}\": described in dictionary but missing from data"
+                        )?,
+                        ColumnIssue::ExtraInData { column, actual } => writeln!(
+                            f,
+                            "  column \"{column}\": present in data ({actual}) but not in dictionary"
+                        )?,
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for DataError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DataError::Schema(e) => Some(e),
+            DataError::Parquet(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+/// Validate a parquet file's columns against a data dictionary.
+///
+/// First validates the dictionary at `dict_path` (schema + lint). Then selects
+/// the table to compare against: `table` if given, otherwise the sole table
+/// when the dictionary describes exactly one. Finally reads the column types of
+/// the parquet file at `parquet_path` and checks every column — reporting type
+/// mismatches, columns described but absent from the data, and columns in the
+/// data the dictionary does not describe.
+pub fn validate_parquet(
+    dict_path: &Path,
+    parquet_path: &Path,
+    table: Option<&str>,
+) -> Result<(), DataError> {
+    let dict = crate::validate_and_lower(dict_path)?;
+
+    let available = || dict.tables.keys().cloned().collect::<Vec<_>>();
+    let table = match table {
+        Some(name) => dict.tables.get(name).ok_or_else(|| DataError::TableNotFound {
+            name: name.to_string(),
+            available: available(),
+        })?,
+        None => {
+            if dict.tables.len() == 1 {
+                dict.tables.values().next().expect("len == 1")
+            } else {
+                return Err(DataError::AmbiguousTable {
+                    available: available(),
+                });
+            }
+        }
+    };
+
+    let actual = data_dict_parquet::column_types(parquet_path)?;
+
+    let mut issues = Vec::new();
+
+    for (name, actual_type) in &actual {
+        match table.column(name) {
+            None => issues.push(ColumnIssue::ExtraInData {
+                column: name.clone(),
+                actual: actual_type.clone(),
+            }),
+            Some(col) => {
+                if let Some(declared) = &col.col_type
+                    && !types_compatible(&declared.value, actual_type)
+                {
+                    issues.push(ColumnIssue::TypeMismatch {
+                        column: name.clone(),
+                        declared: declared.value.clone(),
+                        actual: actual_type.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    for col in &table.columns {
+        if !actual.iter().any(|(n, _)| n == &col.name.value) {
+            issues.push(ColumnIssue::MissingInData {
+                column: col.name.value.clone(),
+            });
+        }
+    }
+
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(DataError::Mismatch {
+            table: table.name.value.clone(),
+            issues,
+        })
+    }
+}
+
+/// Collapse a declared dictionary type to its base form for comparison: any
+/// `number`/`number(...)` measure becomes `number`; everything else is
+/// returned unchanged.
+fn normalize_dict_type(dict_type: &str) -> &str {
+    if dict_type == "number" || dict_type.starts_with("number(") {
+        "number"
+    } else {
+        dict_type
+    }
+}
+
+/// Whether a declared dictionary type is compatible with a type read from the
+/// data (one of `boolean`, `string`, `enum`, `date`, `datetime`, `number`).
+///
+/// Dictionary types are coarser/richer than physical types, so the match is by
+/// category rather than exact string. An `enum` is backed by either a string
+/// or a number in the data (or a true parquet enum), so all three are accepted.
+fn types_compatible(dict_type: &str, actual: &str) -> bool {
+    match normalize_dict_type(dict_type) {
+        "number" => actual == "number",
+        "string" => actual == "string",
+        "boolean" => actual == "boolean",
+        "date" => actual == "date",
+        "datetime" => actual == "datetime",
+        "enum" => matches!(actual, "string" | "number" | "enum"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number_measures_normalize() {
+        assert_eq!(normalize_dict_type("number(quantity)"), "number");
+        assert_eq!(normalize_dict_type("number(id)"), "number");
+        assert_eq!(normalize_dict_type("number"), "number");
+        assert_eq!(normalize_dict_type("string"), "string");
+    }
+
+    #[test]
+    fn compatibility() {
+        assert!(types_compatible("number(quantity)", "number"));
+        assert!(types_compatible("string", "string"));
+        assert!(types_compatible("enum", "string"));
+        assert!(types_compatible("enum", "number"));
+        assert!(types_compatible("enum", "enum"));
+        assert!(!types_compatible("number", "string"));
+        assert!(!types_compatible("date", "datetime"));
+        assert!(!types_compatible("boolean", "number"));
+    }
+}

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -17,10 +17,13 @@ use std::sync::OnceLock;
 use quarto_source_map::SourceContext;
 use quarto_yaml_validation::{Schema, SchemaRegistry, ValidationDiagnostic};
 
+pub mod data;
 pub mod join_expr;
 pub mod lint;
 pub mod lower;
 pub mod model;
+
+use model::DataDict;
 
 const SCHEMA_YAML: &str = include_str!("../../../schema.yaml");
 
@@ -70,6 +73,14 @@ impl std::error::Error for Error {
 /// Validate a `data-dict.yaml` file at `path`: structural schema check
 /// followed by cross-table semantic linting.
 pub fn validate(path: &Path) -> Result<(), Error> {
+    validate_and_lower(path).map(|_| ())
+}
+
+/// Validate a `data-dict.yaml` file at `path` and return the lowered
+/// [`DataDict`] model. Runs the same two passes as [`validate`] — structural
+/// schema check then cross-table semantic linting — and only returns the model
+/// when both succeed.
+pub fn validate_and_lower(path: &Path) -> Result<DataDict, Error> {
     let content = std::fs::read_to_string(path).map_err(Error::Io)?;
     let filename = path.display().to_string();
 
@@ -95,7 +106,7 @@ pub fn validate(path: &Path) -> Result<(), Error> {
         return Err(Error::Invalid(rendered.join("\n")));
     }
 
-    Ok(())
+    Ok(dict)
 }
 
 #[cfg(test)]

--- a/crates/data-dict/tests/validate_parquet.rs
+++ b/crates/data-dict/tests/validate_parquet.rs
@@ -1,0 +1,260 @@
+//! Integration tests for `data_dict::data::validate_parquet`.
+//!
+//! Each test writes a small parquet file (a `string` column `name` and a
+//! `number` column `weight`) and a dictionary YAML to a temp dir, then checks
+//! the outcome of validating one against the other.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use data_dict::data::{validate_parquet, ColumnIssue, DataError};
+use parquet::data_type::{ByteArray, ByteArrayType, DoubleType};
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::parser::parse_message_type;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// A unique temp directory for one test's fixtures.
+fn temp_dir() -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "data-dict-test-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Write a parquet file with a string `name` column and a double `weight`
+/// column.
+fn write_parquet(path: &Path) {
+    let message = "
+        message schema {
+            REQUIRED BYTE_ARRAY name (UTF8);
+            REQUIRED DOUBLE weight;
+        }
+    ";
+    let schema = Arc::new(parse_message_type(message).unwrap());
+    let props = Arc::new(WriterProperties::builder().build());
+    let file = File::create(path).unwrap();
+    let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
+    let mut rg = writer.next_row_group().unwrap();
+
+    let mut col = rg.next_column().unwrap().unwrap();
+    col.typed::<ByteArrayType>()
+        .write_batch(
+            &[ByteArray::from("otter"), ByteArray::from("seal")],
+            None,
+            None,
+        )
+        .unwrap();
+    col.close().unwrap();
+
+    let mut col = rg.next_column().unwrap().unwrap();
+    col.typed::<DoubleType>()
+        .write_batch(&[1.0_f64, 2.0], None, None)
+        .unwrap();
+    col.close().unwrap();
+
+    rg.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Write `yaml` to `<dir>/dict.yaml` and return the path.
+fn write_yaml(dir: &Path, yaml: &str) -> PathBuf {
+    let path = dir.join("dict.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    path
+}
+
+#[test]
+fn matching_dict_and_parquet() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+      - name: weight
+        type: number(quantity)
+        range: [0, 100]
+",
+    );
+
+    assert!(validate_parquet(&yaml, &parquet, None).is_ok());
+}
+
+#[test]
+fn type_mismatch_reported() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    // `weight` is a double in the data but declared as a string here.
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+      - name: weight
+        type: string
+        examples: ['1', '2']
+",
+    );
+
+    let err = validate_parquet(&yaml, &parquet, None).unwrap_err();
+    let DataError::Mismatch { issues, .. } = err else {
+        panic!("expected Mismatch, got {err:?}");
+    };
+    assert!(matches!(
+        issues.as_slice(),
+        [ColumnIssue::TypeMismatch { column, declared, actual }]
+            if column == "weight" && declared == "string" && actual == "number"
+    ));
+}
+
+#[test]
+fn extra_column_in_data_reported() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    // Dictionary omits `weight`, which is present in the parquet file.
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+",
+    );
+
+    let err = validate_parquet(&yaml, &parquet, None).unwrap_err();
+    let DataError::Mismatch { issues, .. } = err else {
+        panic!("expected Mismatch, got {err:?}");
+    };
+    assert!(matches!(
+        issues.as_slice(),
+        [ColumnIssue::ExtraInData { column, actual }]
+            if column == "weight" && actual == "number"
+    ));
+}
+
+#[test]
+fn missing_column_in_data_reported() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    // Dictionary describes `height`, which is absent from the parquet file.
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+      - name: weight
+        type: number(quantity)
+        range: [0, 100]
+      - name: height
+        type: number(quantity)
+        range: [0, 100]
+",
+    );
+
+    let err = validate_parquet(&yaml, &parquet, None).unwrap_err();
+    let DataError::Mismatch { issues, .. } = err else {
+        panic!("expected Mismatch, got {err:?}");
+    };
+    assert!(matches!(
+        issues.as_slice(),
+        [ColumnIssue::MissingInData { column }] if column == "height"
+    ));
+}
+
+#[test]
+fn ambiguous_table_without_name() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+  other:
+    source:
+      parquet: other.parquet
+    columns:
+      - name: id
+        type: number(id)
+        examples: [1, 2]
+",
+    );
+
+    let err = validate_parquet(&yaml, &parquet, None).unwrap_err();
+    assert!(matches!(err, DataError::AmbiguousTable { .. }), "got {err:?}");
+}
+
+#[test]
+fn unknown_table_name() {
+    let dir = temp_dir();
+    let parquet = dir.join("data.parquet");
+    write_parquet(&parquet);
+    let yaml = write_yaml(
+        &dir,
+        "
+version: 0.1.0
+tables:
+  animals:
+    source:
+      parquet: data.parquet
+    columns:
+      - name: name
+        type: string
+        examples: [otter, seal]
+      - name: weight
+        type: number(quantity)
+        range: [0, 100]
+",
+    );
+
+    let err = validate_parquet(&yaml, &parquet, Some("nope")).unwrap_err();
+    assert!(matches!(err, DataError::TableNotFound { .. }), "got {err:?}");
+}

--- a/examples/otters.yaml
+++ b/examples/otters.yaml
@@ -1,5 +1,6 @@
 # source: https://github.com/hadley/otters
 
+version: 0.1.0
 tables:
   otters:
     description: >
@@ -234,6 +235,7 @@ tables:
         description: >
           Unique identifier of pup, if present and marked.
         examples: ["67002", "92-198", "KOD_04_121", "SO-08-20", "SO-98-50a"]
+        constraints: [unique]
 
       - name: pup_sex
         type: enum
@@ -355,6 +357,11 @@ tables:
 
       - name: comments
         type: string
+        examples:
+          - "CL (ventral) 119 cm, CL (foetal) 138 cm"
+          - "died in capture net"
+          - "pupped 10 wks later"
+          - "originally 84-001"
         description: >
           Notes about the capture or collection event.
 


### PR DESCRIPTION
PoC, we'll probably want to organize the CLI commands differently. These are new:

```
❯ cargo run parquet types ../otters/otters.parquet
#   column                         dict type  logical type  physical type
─────────────────────────────────────────────────────────────────────────
1   otter_no                       string     String        BYTE_ARRAY   
2   recap                          number     Integer(i32)  INT32        
3   date                           date       Date          INT32        
4   location                       string     String        BYTE_ARRAY   
5   region                         string     String        BYTE_ARRAY   
6   area                           string     String        BYTE_ARRAY   
...
```

```
❯ cargo run parquet validate examples/otters.yaml ../otters/otters.parquet            
data does not match table "otters" in the data dictionary:
  column "tail_lgth_2": declared number(quantity), data is string
```

```
❯ cargo run parquet validate examples/otters.yaml ../otters/otters.parquet --json | jq
{
  "issues": [
    {
      "actual": "string",
      "column": "tail_lgth_2",
      "declared": "number(quantity)",
      "kind": "type_mismatch"
    }
  ],
  "kind": "mismatch",
  "status": "error",
  "table": "otters"
}
```