### PR TITLE
Validate source is a readable parquet file

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -71,9 +71,16 @@ Implementation, one module per level (entry points re-exported at the crate root
 | metadata (`M##`) | `validate_meta.rs` | `validate-meta` |
 | data (`D##`) | `validate_data.rs` | `validate-data` |
 
-Every level reports through one vocabulary in `problem.rs`: a `Problem` (a `code`, `severity`, `message`, optional `expected`/`column`/`hint`/`span`, and a flattened `ProblemKind` tag covering pre-flight, spec, metadata, and data findings alike) and a `ProblemSet` (one vector of them plus the `SourceContext` for rendering). `serde` derives the JSON wire format directly; there is no separate error type. "Fatal" is not a field — a level pushes its problems and returns early to stop the run, and the meta/data levels descend only while `ProblemSet::has_errors()` is false. `Level` and the `select_table` helper live in `lib.rs`. Each level's entry point drives its own flow (no central dispatcher).
+Every level reports through one vocabulary in `problem.rs`: a `Problem` (a `code`, `severity`, `message`, optional `expected`/`column`/`hint`/`span`, and a flattened `ProblemKind` tag covering pre-flight, spec, metadata, and data findings alike) and a `ProblemSet` (one vector of them plus the `SourceContext` for rendering). `serde` derives the JSON wire format directly; there is no separate error type. "Fatal" is not a field — a level pushes its problems and returns early to stop the run, and the meta/data levels descend only while `ProblemSet::has_errors()` is false. `Level`, the `select_tables` helper, and the `compare_dataset`/`read_parquet` driver live in `lib.rs`. Each level's entry point drives its own flow (no central dispatcher).
 
 Test fixtures for the spec rules are in `crates/data-dict/tests/fixtures/{valid,invalid,spec}/`. Each fixture has a `# expected: ...` header documenting the intended outcome. Integration tests mirror the levels: `tests/validate_spec.rs` / `validate_meta.rs` / `validate_data.rs`.
+
+### Problem reporting
+
+Two principles guide how problems are surfaced:
+
+- **Full context.** A problem should carry enough context that the user can see at a glance where it comes from — point at the offending span and fade in its enclosing nodes (e.g. the table and column a bad value sits in), so the location is unambiguous without re-reading the file.
+- **Report as many problems as possible at once.** Prefer collecting all the problems in a pass over bailing on the first, so the user fixes them together rather than rerunning repeatedly. Not always possible (a problem can block the checks that would follow it), but worth striving for.
 
 ### Diagnostic wording
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The `data-dict` CLI validates dictionaries at [three levels](https://data-dict.t
 * Check that a file is structurally valid and internally consistent
   (`validate-spec`). Pass a file, or a directory containing a
   `data-dict.yaml` (defaults to the current directory).
-* Compare a dictionary against a real Parquet file's column names and types
-  (`validate-meta`), or against its values too (`validate-data`).
+* Compare a dictionary against its tables' data — column names and types
+  (`validate-meta`), or values too (`validate-data`). The data is located
+  through each table's `source`, so only the dictionary is passed.
 * Print the column types of a Parquet file (`types parquet`).
 * Print an embedded agent skill for reading or writing data dictionaries
   (`skill read` / `skill write`).

--- a/crates/data-dict-cli/skills/write-data-dict.md
+++ b/crates/data-dict-cli/skills/write-data-dict.md
@@ -104,10 +104,10 @@ a plausible-sounding description for a column whose meaning you had to guess.
 
     -   Run `data-dict validate-spec data-dict.yaml` to confirm it is
         structurally valid and passes the spec checks.
-    -   For each parquet table, run
-        `data-dict validate-data data-dict.yaml <file>` to confirm every
-        declared type matches the physical data. Fix any mismatch it reports --
-        change the `type`, not the data.
+    -   Run `data-dict validate-data data-dict.yaml` to confirm every declared
+        type matches the physical data. It reads each table's data through its
+        `source`, so make sure every table declares one. Fix any mismatch it
+        reports -- change the `type`, not the data.
     -   Confirm by inspection: do all column names match? Do primary keys
         actually uniquely identify rows? Do foreign key values exist in the
         referenced table? Are `required` columns truly non-null?

--- a/crates/data-dict-cli/src/main.rs
+++ b/crates/data-dict-cli/src/main.rs
@@ -33,11 +33,11 @@ enum Command {
     },
 }
 
-/// Shared arguments for `validate-meta` and `validate-data`.
+/// Shared arguments for `validate-meta` and `validate-data`. 
 #[derive(clap::Args)]
 struct ValidateArgs {
     dict: PathBuf,
-    parquet: PathBuf,
+    /// Validate only this table, instead of every table in the dictionary
     #[arg(long)]
     table: Option<String>,
     /// Emit results as JSON
@@ -176,7 +176,7 @@ fn resolve_dict_path(path: Option<PathBuf>) -> Result<PathBuf, String> {
 
 /// A validation entry point: `validate_meta` or `validate_data`. Both share the
 /// signature, so `run_validate` is generic over which one it drives.
-type ValidateFn = fn(&Path, &Path, Option<&str>) -> ProblemSet;
+type ValidateFn = fn(&Path, Option<&str>) -> ProblemSet;
 
 /// Run a meta or data validation and turn its outcome into rendered output and
 /// an exit code.
@@ -188,7 +188,7 @@ fn run_validate(args: ValidateArgs, validate: ValidateFn) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let problems = validate(&dict, &args.parquet, args.table.as_deref());
+    let problems = validate(&dict, args.table.as_deref());
     let status = problems.status();
     if args.json {
         println!("{}", problems_to_json(&problems));
@@ -197,7 +197,7 @@ fn run_validate(args: ValidateArgs, validate: ValidateFn) -> ExitCode {
             eprintln!("{line}");
         }
         if !status.failed() {
-            println!("{}: ok", args.parquet.display());
+            println!("{}: ok", dict.display());
         }
     }
     if status.failed() {
@@ -370,14 +370,14 @@ mod tests {
     #[test]
     fn json_reports_error_status() {
         let problems = ProblemSet::from_preflight(
-            data_dict::ProblemKind::AmbiguousTable {
+            data_dict::ProblemKind::TableNotFound {
                 available: vec!["a".to_string(), "b".to_string()],
             },
-            "the data dictionary describes multiple tables",
+            "table \"x\" is not in the data dictionary",
         );
         let json = problems_to_json(&problems);
         assert_eq!(json["status"], "error");
-        assert_eq!(json["problems"][0]["kind"], "ambiguous_table");
+        assert_eq!(json["problems"][0]["kind"], "table_not_found");
         assert_eq!(json["problems"][0]["available"][1], "b");
     }
 }

--- a/crates/data-dict-cli/tests/cli.rs
+++ b/crates/data-dict-cli/tests/cli.rs
@@ -19,8 +19,8 @@ fn no_args_lists_all_subcommands() {
 }
 
 /// A fixture that fails schema validation with two errors (S07, S08) and a warning (S09),
-/// in that emission order. Validating it against a parquet file skips the data
-/// comparison (the dictionary has errors), so the parquet path is never read.
+/// in that emission order. Validating its data skips the data comparison (the
+/// dictionary has errors), so no source is ever read.
 fn multi_error_fixture() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/multi-error-with-warning.yaml")
 }
@@ -33,7 +33,6 @@ fn multiple_diagnostics_text_output() {
     let output = Command::new(env!("CARGO_BIN_EXE_data-dict"))
         .args(["validate-data"])
         .arg(&fixture)
-        .arg("ignored.parquet")
         .output()
         .expect("failed to run data-dict");
     assert!(!output.status.success());
@@ -49,7 +48,7 @@ fn multiple_diagnostics_json_output() {
     let output = Command::new(env!("CARGO_BIN_EXE_data-dict"))
         .args(["validate-data"])
         .arg(&fixture)
-        .args(["ignored.parquet", "--json"])
+        .arg("--json")
         .output()
         .expect("failed to run data-dict");
     assert!(!output.status.success());

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -9,10 +9,10 @@
 //! metadata or data mismatch). A level pushes its problems and stops the run
 //! short by returning early; the meta and data levels validate the spec first
 //! and compare against a dataset only when it is free of errors. This module
-//! holds the shared [`Level`], the [`select_table`] helper, and the
-//! `compare_dataset` driver the meta and data levels build on.
+//! holds the shared [`Level`] and the `compare_dataset` driver the meta and
+//! data levels build on.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub mod join_expr;
 pub mod lower;
@@ -43,13 +43,17 @@ pub enum Level {
 }
 
 /// The shared prologue for `validate_meta` and `validate_data`, so they differ
-/// only in the `checks` they pass. Each step bails out on failure, reporting only
-/// what it has by then.
+/// only in the `checks` they pass.
+///
+/// Validates the spec first and stops if it has errors. Otherwise it validates
+/// every table (or just `table`, when named), locating each table's data through
+/// its `source` and reading the parquet file `source.parquet` points at, resolved
+/// relative to `dict_path`. A table with no `source` (M04) or an unreadable one
+/// (M05) is reported and skipped; the remaining tables are still checked.
 pub(crate) fn compare_dataset(
     dict_path: &Path,
-    parquet_path: &Path,
     table: Option<&str>,
-    checks: impl FnOnce(&Table, &[(String, String)], &mut ProblemSet),
+    checks: impl Fn(&Table, &Path, &[(String, String)], &mut ProblemSet),
 ) -> ProblemSet {
     let (mut problems, doc) = match load(dict_path) {
         Ok(loaded) => loaded,
@@ -58,33 +62,66 @@ pub(crate) fn compare_dataset(
     let Some(dict) = validate_and_lower(&doc, &mut problems) else {
         return problems;
     };
-    let Some(table) = select_table(&dict, table, &mut problems) else {
+    let Some(tables) = select_tables(&dict, table, &mut problems) else {
         return problems;
     };
-    let actual = match data_dict_parquet::column_types(parquet_path) {
-        Ok(actual) => actual,
-        Err(e) => {
-            problems.push(Problem::preflight(ProblemKind::Parquet, e.to_string()));
-            return problems;
+    let base_dir = dict_path.parent().unwrap_or_else(|| Path::new(""));
+    for table in tables {
+        if let Some((parquet_path, actual)) = read_parquet(table, base_dir, &mut problems) {
+            checks(table, &parquet_path, &actual, &mut problems);
         }
-    };
-    checks(table, &actual, &mut problems);
+    }
     problems
 }
 
-/// Falls back to the sole table when `table` is `None` and the dictionary
-/// describes exactly one; otherwise records why in `out` and returns `None`.
-pub(crate) fn select_table<'a>(
+/// Locate and read a table's data from its `source`, returning the resolved
+/// parquet path and its column schema. Reports the source problem and returns
+/// `None` when the table has no `source` (M04) or its parquet file can't be read
+/// (M05), so the caller skips it.
+fn read_parquet(
+    table: &Table,
+    base_dir: &Path,
+    out: &mut ProblemSet,
+) -> Option<(PathBuf, Vec<(String, String)>)> {
+    let Some(source) = &table.source else {
+        out.push_located(
+            ProblemKind::MissingSource,
+            Severity::Error,
+            "A table validated against data must declare a `source`.",
+            "has no `source`",
+            [table.name.span.clone()],
+        );
+        return None;
+    };
+    let parquet_path = base_dir.join(&source.parquet.value);
+    match data_dict_parquet::column_types(&parquet_path) {
+        Ok(actual) => Some((parquet_path, actual)),
+        Err(e) => {
+            out.push_located(
+                ProblemKind::UnreadableSource,
+                Severity::Error,
+                "A table's `source` must point at a readable Parquet file.",
+                e.to_string(),
+                [source.span.clone(), source.parquet.span.clone()],
+            );
+            None
+        }
+    }
+}
+
+/// The tables to validate: the one named by `table`, or all of them. Records a
+/// `TableNotFound` pre-flight failure and returns `None` when a named table is
+/// absent.
+fn select_tables<'a>(
     dict: &'a DataDict,
     table: Option<&str>,
     out: &mut ProblemSet,
-) -> Option<&'a Table> {
-    let available = || dict.tables.keys().cloned().collect::<Vec<_>>();
+) -> Option<Vec<&'a Table>> {
     match table {
         Some(name) => match dict.tables.get(name) {
-            Some(table) => Some(table),
+            Some(table) => Some(vec![table]),
             None => {
-                let available = available();
+                let available = dict.tables.keys().cloned().collect::<Vec<_>>();
                 out.push(Problem::preflight(
                     ProblemKind::TableNotFound {
                         available: available.clone(),
@@ -97,22 +134,6 @@ pub(crate) fn select_table<'a>(
                 None
             }
         },
-        None => {
-            if dict.tables.len() == 1 {
-                Some(dict.tables.values().next().expect("len == 1"))
-            } else {
-                let available = available();
-                out.push(Problem::preflight(
-                    ProblemKind::AmbiguousTable {
-                        available: available.clone(),
-                    },
-                    format!(
-                        "the data dictionary describes multiple tables ({}); specify which one to validate against",
-                        available.join(", ")
-                    ),
-                ));
-                None
-            }
-        }
+        None => Some(dict.tables.values().collect()),
     }
 }

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -102,7 +102,11 @@ fn read_parquet(
                 Severity::Error,
                 "A table's `source` must point at a readable Parquet file.",
                 e.to_string(),
-                [source.span.clone(), source.parquet.span.clone()],
+                [
+                    table.name.span.clone(),
+                    source.span.clone(),
+                    source.parquet.span.clone(),
+                ],
             );
             None
         }

--- a/crates/data-dict/src/lower.rs
+++ b/crates/data-dict/src/lower.rs
@@ -10,7 +10,8 @@ use quarto_yaml::YamlWithSourceInfo;
 
 use crate::join_expr::JoinExpr;
 use crate::model::{
-    Cardinality, Column, Constraint, DataDict, Relationship, Representation, Scalar, Spanned, Table,
+    Cardinality, Column, Constraint, DataDict, Relationship, Representation, Scalar, Source,
+    Spanned, Table,
 };
 use crate::problem::{Problem, ProblemSet, Severity};
 
@@ -56,9 +57,14 @@ fn lower_table(name: &str, name_span: &SourceInfo, value: &YamlWithSourceInfo) -
             }
         }
     }
-    let source = value
-        .get_hash_value("source")
-        .map(|n| n.source_info.clone());
+    let source = value.get_hash_value("source").and_then(|n| {
+        let parquet = n.get_hash_value("parquet")?;
+        let path = parquet.yaml.as_str()?;
+        Some(Source {
+            span: n.source_info.clone(),
+            parquet: Spanned::new(path.to_string(), parquet.source_info.clone()),
+        })
+    });
     Table {
         name: Spanned::new(name.to_string(), name_span.clone()),
         columns,

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -32,9 +32,16 @@ pub struct DataDict {
 pub struct Table {
     pub name: Spanned<String>,
     pub columns: Vec<Column>,
-    /// The `source` node's span, when the table declares one. Optional at the
-    /// spec level; the metadata level requires it (M04).
-    pub source: Option<SourceInfo>,
+    /// Where the table's data lives, when it declares a `source`. Optional 
+    /// for spec validation; required for metadata validation (M04).
+    pub source: Option<Source>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Source {
+    pub span: SourceInfo,
+    /// path relative to dictionary
+    pub parquet: Spanned<String>,
 }
 
 impl Table {

--- a/crates/data-dict/src/problem.rs
+++ b/crates/data-dict/src/problem.rs
@@ -103,8 +103,6 @@ pub enum ProblemKind {
     Parquet,
     /// A table name was given but no such table exists.
     TableNotFound { available: Vec<String> },
-    /// No table name was given and the dictionary describes more than one.
-    AmbiguousTable { available: Vec<String> },
     /// A semantic spec check (`S##`) failed; the specific code is in
     /// [`Problem::code`] and the detail in [`Problem::message`].
     Spec,
@@ -116,6 +114,9 @@ pub enum ProblemKind {
     ExtraInData { actual: String },
     /// `M04` — a table validated against data declares no `source`.
     MissingSource,
+    /// `M05` — a table's `source` is declared but its data can't be read (the
+    /// `parquet` file is absent or unreadable).
+    UnreadableSource,
     /// `D01` — a `required` (or `primary_key`) column contains nulls. `rows`
     /// lists the first few offending row numbers (1-based); `count` is the total.
     NullsInRequired { count: usize, rows: Vec<usize> },
@@ -131,6 +132,7 @@ impl ProblemKind {
             ProblemKind::MissingInData => "M02",
             ProblemKind::ExtraInData { .. } => "M03",
             ProblemKind::MissingSource => "M04",
+            ProblemKind::UnreadableSource => "M05",
             ProblemKind::NullsInRequired { .. } => "D01",
             _ => return None,
         })
@@ -144,7 +146,8 @@ impl ProblemKind {
             ProblemKind::TypeMismatch { .. }
             | ProblemKind::MissingInData
             | ProblemKind::ExtraInData { .. }
-            | ProblemKind::MissingSource => Level::Meta,
+            | ProblemKind::MissingSource
+            | ProblemKind::UnreadableSource => Level::Meta,
             ProblemKind::NullsInRequired { .. } => Level::Data,
             _ => return None,
         })
@@ -491,13 +494,13 @@ mod tests {
     #[test]
     fn preflight_problem_json_has_kind_but_no_code() {
         let p = Problem::preflight(
-            ProblemKind::AmbiguousTable {
+            ProblemKind::TableNotFound {
                 available: vec!["a".into(), "b".into()],
             },
-            "the dictionary describes multiple tables",
+            "table \"x\" is not in the data dictionary",
         );
         let v = serde_json::to_value(&p).unwrap();
-        assert_eq!(v["kind"], "ambiguous_table");
+        assert_eq!(v["kind"], "table_not_found");
         assert_eq!(v["available"], serde_json::json!(["a", "b"]));
         assert_eq!(v["severity"], "error");
         assert!(v.get("code").is_none());

--- a/crates/data-dict/src/validate_data.rs
+++ b/crates/data-dict/src/validate_data.rs
@@ -21,8 +21,8 @@ const SAMPLE_LIMIT: usize = 5;
 /// metadata-level check ([`crate::validate_meta`]) plus the value-level checks
 /// below: reading the columns and pages the checks imply and reporting, for
 /// example, nulls in a required column.
-pub fn validate_data(dict_path: &Path, parquet_path: &Path, table: Option<&str>) -> ProblemSet {
-    crate::compare_dataset(dict_path, parquet_path, table, |table, actual, problems| {
+pub fn validate_data(dict_path: &Path, table: Option<&str>) -> ProblemSet {
+    crate::compare_dataset(dict_path, table, |table, parquet_path, actual, problems| {
         crate::validate_meta::meta_issues(table, actual, problems);
         if let Err(e) = value_issues(table, parquet_path, actual, problems) {
             problems.push(Problem::preflight(ProblemKind::Parquet, e.to_string()));

--- a/crates/data-dict/src/validate_meta.rs
+++ b/crates/data-dict/src/validate_meta.rs
@@ -2,21 +2,23 @@
 //!
 //! [`validate_meta`] is the entry point; [`meta_issues`] is the reusable core
 //! that the data level ([`crate::validate_data`]) runs before its own value checks.
+//! The source checks (M04, M05) live in [`crate::compare_dataset`], which locates
+//! and reads each table's data before these column checks run.
 
 use std::path::Path;
 
 use crate::model::Table;
 use crate::problem::{Problem, ProblemKind, ProblemSet, Severity};
 
-/// Validate a parquet file's column names and types against a data dictionary.
+/// Validate every table's column names and types against a data dictionary.
 ///
-/// Validates the spec first, then — when it is free of errors — compares the
-/// parquet file's column schema against the selected table, reporting type
+/// Validates the spec first, then — when it is free of errors — compares each
+/// table's `source` data against its dictionary entry, reporting type
 /// mismatches, columns described but absent from the data, and columns in the
 /// data the dictionary does not describe. Values are never read; see
 /// [`crate::validate_data::validate_data`] for the level that does.
-pub fn validate_meta(dict_path: &Path, parquet_path: &Path, table: Option<&str>) -> ProblemSet {
-    crate::compare_dataset(dict_path, parquet_path, table, |table, actual, problems| {
+pub fn validate_meta(dict_path: &Path, table: Option<&str>) -> ProblemSet {
+    crate::compare_dataset(dict_path, table, |table, _parquet, actual, problems| {
         meta_issues(table, actual, problems);
     })
 }
@@ -25,22 +27,9 @@ pub fn validate_meta(dict_path: &Path, parquet_path: &Path, table: Option<&str>)
 /// the data, pushing the metadata-level problems into `out`. Reused by the data
 /// level, which appends its value-level problems to the same set.
 pub(crate) fn meta_issues(table: &Table, actual: &[(String, String)], out: &mut ProblemSet) {
-    validate_m04_source(table, out);
     validate_m01_column_types(table, actual, out);
     validate_m02_missing_columns(table, actual, out);
     validate_m03_extra_columns(table, actual, out);
-}
-
-fn validate_m04_source(table: &Table, out: &mut ProblemSet) {
-    if table.source.is_none() {
-        out.push_located(
-            ProblemKind::MissingSource,
-            Severity::Error,
-            "A table validated against data must declare a `source`.",
-            "has no `source`",
-            [table.name.span.clone()],
-        );
-    }
 }
 
 fn validate_m01_column_types(table: &Table, actual: &[(String, String)], out: &mut ProblemSet) {

--- a/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_does_not_stop_other_tables.snap
+++ b/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_does_not_stop_other_tables.snap
@@ -12,3 +12,14 @@ Error: [M05] A table's `source` must point at a readable Parquet file.
    │                       ╰───────── Parquet error: Cannot open file: No such file or directory (os error 2)
    ┆ 
 ───╯
+
+Error: [M01] A column's data must match its declared type.
+    ╭─[ dict.yaml:19:15 ]
+    │
+ 11 │   plants:
+    │ 
+ 18 │       - name: weight
+ 19 │         type: string
+    │               ───┬──  
+    │                  ╰──── the data is `number`
+────╯

--- a/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_reported.snap
+++ b/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_reported.snap
@@ -1,0 +1,12 @@
+---
+source: crates/data-dict/tests/validate_meta.rs
+expression: "common::sanitize(&problems.render().join(\"\\n\"), &dir)"
+---
+Error: [M05] A table's `source` must point at a readable Parquet file.
+   ╭─[ dict.yaml:6:16 ]
+   │
+ 6 │       parquet: missing.parquet
+   │                ───────┬───────  
+   │                       ╰───────── Parquet error: Cannot open file: No such file or directory (os error 2)
+   ┆ 
+───╯

--- a/crates/data-dict/tests/validate_data.rs
+++ b/crates/data-dict/tests/validate_data.rs
@@ -25,20 +25,20 @@ fn check_column(
     write: impl FnOnce(&mut SerializedColumnWriter),
     column: &str,
 ) -> ProblemSet {
-    let (yaml, parquet) = build_column(schema_col, write, column);
-    validate_data(&yaml, &parquet, None)
+    let yaml = build_column(schema_col, write, column);
+    validate_data(&yaml, None)
 }
 
 /// Write a one-column parquet file (`schema_col` is that column's line in a
 /// parquet message-type schema, e.g. `OPTIONAL DOUBLE weight`; `write` fills in
 /// its data) and wrap `column` — the YAML for one `columns:` entry — in an
-/// otherwise-minimal one-table dictionary. Returns their paths so a test can run
-/// more than one validation level against the same pair.
+/// otherwise-minimal one-table dictionary whose `source` points at that file.
+/// Returns the dictionary path.
 fn build_column(
     schema_col: &str,
     write: impl FnOnce(&mut SerializedColumnWriter),
     column: &str,
-) -> (PathBuf, PathBuf) {
+) -> PathBuf {
     let dir = temp_dir();
     let parquet = dir.join("data.parquet");
 
@@ -61,7 +61,7 @@ fn build_column(
         .map(|line| format!("      {line}"))
         .collect::<Vec<_>>()
         .join("\n");
-    let yaml = write_yaml(
+    write_yaml(
         &dir,
         &formatdoc! {"
             $version: 0.1.0
@@ -73,9 +73,7 @@ fn build_column(
                 columns:
             {column}
         "},
-    );
-
-    (yaml, parquet)
+    )
 }
 
 /// Write an optional double column whose second row (1-based) is null.
@@ -92,7 +90,7 @@ fn write_double_with_null(col: &mut SerializedColumnWriter) {
 /// reads only names and types) but caught by `validate-data` (which scans).
 #[test]
 fn meta_ignores_null_values_that_data_catches() {
-    let (yaml, parquet) = build_column(
+    let yaml = build_column(
         "OPTIONAL DOUBLE weight",
         write_double_with_null,
         indoc! {"
@@ -104,11 +102,11 @@ fn meta_ignores_null_values_that_data_catches() {
     );
 
     // Metadata level: the column exists with a compatible type, so it's clean.
-    let meta = validate_meta(&yaml, &parquet, None);
+    let meta = validate_meta(&yaml, None);
     assert_eq!(meta.status(), Status::Ok, "meta got {:?}", meta.items);
 
     // Data level: the null in a required column is an error.
-    let data = validate_data(&yaml, &parquet, None);
+    let data = validate_data(&yaml, None);
     assert_eq!(data.status(), Status::Error);
     assert!(
         matches!(
@@ -126,7 +124,7 @@ fn meta_ignores_null_values_that_data_catches() {
 
 #[test]
 fn nulls_in_required_column_reported() {
-    let (yaml, parquet) = build_column(
+    let yaml = build_column(
         "OPTIONAL DOUBLE weight",
         write_double_with_null,
         indoc! {"
@@ -136,7 +134,7 @@ fn nulls_in_required_column_reported() {
               range: [0, 100]
         "},
     );
-    let result = validate_data(&yaml, &parquet, None);
+    let result = validate_data(&yaml, None);
 
     assert_eq!(result.status(), Status::Error);
     assert!(

--- a/crates/data-dict/tests/validate_meta.rs
+++ b/crates/data-dict/tests/validate_meta.rs
@@ -35,7 +35,7 @@ fn matching_dict_and_parquet() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(problems.status(), Status::Ok, "got {:?}", problems.items);
 }
 
@@ -64,7 +64,7 @@ fn type_mismatch_reported() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(problems.status(), Status::Error);
     assert!(matches!(
         problems.items.as_slice(),
@@ -99,7 +99,7 @@ fn extra_column_in_data_is_warning() {
 
     // An undocumented column is a warning, not an error: it is reported but does
     // not fail validation.
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(
         problems.status(),
         Status::Warning,
@@ -138,7 +138,7 @@ fn typeless_column_skips_type_check_for_present_column() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(problems.status(), Status::Ok, "got {:?}", problems.items);
 }
 
@@ -169,7 +169,7 @@ fn typeless_column_still_must_exist_in_data() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(problems.status(), Status::Error);
     assert!(matches!(
         problems.items.as_slice(),
@@ -208,7 +208,7 @@ fn missing_column_in_data_reported() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert_eq!(problems.status(), Status::Error);
     assert!(matches!(
         problems.items.as_slice(),
@@ -222,10 +222,12 @@ fn missing_column_in_data_reported() {
 }
 
 #[test]
-fn ambiguous_table_without_name() {
+fn validates_every_table() {
     let dir = temp_dir();
-    let parquet = dir.join("data.parquet");
-    write_parquet(&parquet);
+    write_parquet(&dir.join("animals.parquet"));
+    write_parquet(&dir.join("plants.parquet"));
+    // Two tables, each with its own source. `animals` matches its data; `plants`
+    // declares a `height` column its data lacks (M02). One run checks both.
     let yaml = write_yaml(
         &dir,
         indoc! {"
@@ -234,33 +236,79 @@ fn ambiguous_table_without_name() {
             tables:
               animals:
                 source:
-                  parquet: data.parquet
+                  parquet: animals.parquet
                 columns:
                   - name: name
                     type: string
                     examples: [otter, seal]
-              other:
+                  - name: weight
+                    type: number(quantity)
+                    range: [0, 100]
+              plants:
                 source:
-                  parquet: other.parquet
+                  parquet: plants.parquet
                 columns:
-                  - name: id
-                    type: number(id)
-                    examples: [1, 2]
+                  - name: name
+                    type: string
+                    examples: [moss, fern]
+                  - name: weight
+                    type: number(quantity)
+                    range: [0, 100]
+                  - name: height
+                    type: number(quantity)
+                    range: [0, 100]
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
+    assert_eq!(problems.status(), Status::Error);
+    assert!(
+        problems
+            .items
+            .iter()
+            .any(|p| p.code == Some("M02") && p.severity == Severity::Error),
+        "expected plants/height to be reported as M02, got {:?}",
+        problems.items
+    );
+}
+
+#[test]
+fn unreadable_source_reported() {
+    let dir = temp_dir();
+    // The table declares a `source`, but the parquet file it names does not exist.
+    let yaml = write_yaml(
+        &dir,
+        indoc! {"
+            $version: 0.1.0
+            $learn_more: http://data-dict.tidyverse.org/
+            tables:
+              animals:
+                source:
+                  parquet: missing.parquet
+                columns:
+                  - name: name
+                    type: string
+                    examples: [otter, seal]
+        "},
+    );
+
+    let problems = validate_meta(&yaml, None);
+    assert_eq!(problems.status(), Status::Error);
     assert!(
         matches!(
             problems.items.as_slice(),
             [Problem {
-                kind: ProblemKind::AmbiguousTable { .. },
+                code: Some(code),
+                kind: ProblemKind::UnreadableSource,
+                severity: Severity::Error,
                 ..
-            }]
+            }] if *code == "M05"
         ),
         "got {:?}",
         problems.items
     );
+    #[cfg(unix)]
+    insta::assert_snapshot!(common::sanitize(&problems.render().join("\n"), &dir));
 }
 
 #[test]
@@ -287,7 +335,7 @@ fn unknown_table_name() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, Some("nope"));
+    let problems = validate_meta(&yaml, Some("nope"));
     assert!(
         matches!(
             problems.items.as_slice(),
@@ -304,8 +352,6 @@ fn unknown_table_name() {
 #[test]
 fn missing_source_reported() {
     let dir = temp_dir();
-    let parquet = dir.join("data.parquet");
-    write_parquet(&parquet);
     // The table declares no `source`; valid at the spec level, but M04 at meta.
     let yaml = write_yaml(
         &dir,
@@ -324,7 +370,7 @@ fn missing_source_reported() {
         "},
     );
 
-    let problems = validate_meta(&yaml, &parquet, None);
+    let problems = validate_meta(&yaml, None);
     assert!(
         problems
             .items

--- a/crates/data-dict/tests/validate_meta.rs
+++ b/crates/data-dict/tests/validate_meta.rs
@@ -312,6 +312,55 @@ fn unreadable_source_reported() {
 }
 
 #[test]
+fn unreadable_source_does_not_stop_other_tables() {
+    let dir = temp_dir();
+    // `plants` has real data; `animals` points at a file that doesn't exist. The
+    // missing source (M05) is reported, but `plants` is still checked, where its
+    // declared `weight` type disagrees with the data (M01).
+    write_parquet(&dir.join("plants.parquet"));
+    let yaml = write_yaml(
+        &dir,
+        indoc! {"
+            $version: 0.1.0
+            $learn_more: http://data-dict.tidyverse.org/
+            tables:
+              animals:
+                source:
+                  parquet: missing.parquet
+                columns:
+                  - name: name
+                    type: string
+                    examples: [otter, seal]
+              plants:
+                source:
+                  parquet: plants.parquet
+                columns:
+                  - name: name
+                    type: string
+                    examples: [moss, fern]
+                  - name: weight
+                    type: string
+                    examples: ['1', '2']
+        "},
+    );
+
+    let problems = validate_meta(&yaml, None);
+    assert_eq!(problems.status(), Status::Error);
+    assert!(
+        problems.items.iter().any(|p| p.code == Some("M05")),
+        "expected an M05 unreadable-source error, got {:?}",
+        problems.items
+    );
+    assert!(
+        problems.items.iter().any(|p| p.code == Some("M01")),
+        "expected an M01 type-mismatch error from the readable table, got {:?}",
+        problems.items
+    );
+    #[cfg(unix)]
+    insta::assert_snapshot!(common::sanitize(&problems.render().join("\n"), &dir));
+}
+
+#[test]
 fn unknown_table_name() {
     let dir = temp_dir();
     let parquet = dir.join("data.parquet");

--- a/site/spec.md
+++ b/site/spec.md
@@ -69,11 +69,11 @@ source:
   parquet: inst/parquet/food.parquet
 ```
 
-* `parquet`: path to a Parquet file (may include globs).
+* `parquet`: path to a Parquet file (may include globs). Relative paths are resolved relative to the dictionary file.
 
 Parquet is the only source `data-dict` can currently validate against, so it's the only one the spec defines. We expect to add more access methods in the future — most importantly `SQL` (a schema-qualified table name such as `foodbank.food`, or a full `SELECT` query), and likely others such as R, Python, and Posit Connect pins.
 
-`source` is optional while you're only validating the spec, letting you sketch a table before its data exists. But the metadata and data levels validate the dictionary against real data, so they require every table they check to declare a `source`.
+`source` is optional while you're only validating the spec, letting you sketch a table before its data exists. But the metadata and data levels validate the dictionary against real data, so every table they check must declare a `source` whose file exists and is readable.
 
 ### Columns
 

--- a/site/validation.md
+++ b/site/validation.md
@@ -12,6 +12,8 @@ Validation happens at three levels, each a strict superset of the one before it:
 
 The last two levels compare the dictionary against the data (or equivalently, the data against the dictionary). When they disagree, we can't tell which side needs to change. If you're creating the dictionary as you learn about the data, then you might need to change the dictionary. If you're using the dictionary to validate a dataset, there might be an upstream issue that you need to resolve.
 
+The metadata and data levels locate each table's data through its [`source`](spec.md#source): they read the file the table's `source.parquet` points at, resolved relative to the dictionary file. They validate **every** table in the dictionary, each against its own source, so a single run checks the whole dictionary. A problem in one table (an unreadable source, a column mismatch) is reported against that table and does not stop the others from being checked.
+
 Each level implies the ones before it: validating the metadata validates the spec first, and validating the data validates both the spec and the metadata first. Validating the spec and metadata are cheap, so they can be run continually while you edit the `data-dict.yaml`; validating the data adds a full scan and get more expensive as the size of the data increases.
 
 Each check has a code prefixed by its level: spec checks are `S01`, `S02`, …; metadata checks `M01`, …; data checks `D01`, …. Severity is independent of level — any level can raise errors or warnings.
@@ -54,6 +56,7 @@ When validating the data's metadata against the dictionary, each column mismatch
 * **Missing column** (M02, error): a column the dictionary describes is absent from the data. This applies even to columns listed by name only — listing a column that doesn't exist is an error.
 * **Undocumented column** (M03, warning): a column present in the data that the dictionary does not describe. This is a warning, not an error: if a production pipeline adds a column, validation should not fail, but you should document it (or at least list it by name) next time you touch the dictionary.
 * **Missing source** (M04, error): a table validated against data does not declare a `source`. `source` is optional at the spec level but required here, so a validated dictionary always records where its data comes from.
+* **Unreadable source** (M05, error): a table declares a `source`, but its data can't be read — the `source.parquet` file is absent, or present but not a readable Parquet file. The path is resolved relative to the dictionary file.
 
 ## Data-validation checks
 


### PR DESCRIPTION
Also changes `validate-meta` and `validate-data` so that they validate all sources by default.

Fixes #91