### PR TITLE
Fill single-line gaps between context lines in diagnostics

### DIFF
--- a/crates/data-dict/src/problem.rs
+++ b/crates/data-dict/src/problem.rs
@@ -14,7 +14,7 @@
 //! descending. Fatality is control flow, not data.
 
 use quarto_error_reporting::DiagnosticMessageBuilder;
-use quarto_source_map::{SourceContext, SourceInfo};
+use quarto_source_map::{FileId, SourceContext, SourceInfo};
 
 use crate::Level;
 
@@ -247,6 +247,9 @@ impl Problem {
         for ctx_span in &self.context {
             builder = builder.add_faded_at("", ctx_span.clone());
         }
+        for gap_span in gap_fill_spans(&self.context, span, ctx) {
+            builder = builder.add_faded_at("", gap_span);
+        }
         builder = builder
             .problem(self.message.clone())
             .with_location(span.clone());
@@ -268,6 +271,55 @@ impl Problem {
         }
         line
     }
+}
+
+/// Fill any single-line gap between the context chunks
+fn gap_fill_spans(
+    context: &[SourceInfo],
+    primary: &SourceInfo,
+    ctx: &SourceContext,
+) -> Vec<SourceInfo> {
+    use std::collections::{BTreeSet, HashMap};
+
+    let mut rows_by_file: HashMap<FileId, BTreeSet<usize>> = HashMap::new();
+    for span in context.iter().chain(std::iter::once(primary)) {
+        if let Some(loc) = span.map_offset(0, ctx) {
+            rows_by_file
+                .entry(loc.file_id)
+                .or_default()
+                .insert(loc.location.row);
+        }
+    }
+
+    let mut fills = Vec::new();
+    for (file_id, rows) in rows_by_file {
+        let Some(content) = ctx.get_file(file_id).and_then(|f| f.content.as_deref()) else {
+            continue;
+        };
+        let rows: Vec<usize> = rows.into_iter().collect();
+        for pair in rows.windows(2) {
+            if pair[1] == pair[0] + 2
+                && let Some(span) = line_span(file_id, content, pair[0] + 1)
+            {
+                fills.push(span);
+            }
+        }
+    }
+    fills
+}
+
+/// A span covering the content of 0-based `row` in `content` (excluding the
+/// trailing newline), or `None` if the file has no such line.
+fn line_span(file_id: FileId, content: &str, row: usize) -> Option<SourceInfo> {
+    let mut start = 0;
+    for (i, line) in content.split_inclusive('\n').enumerate() {
+        if i == row {
+            let end = start + line.trim_end_matches(['\r', '\n']).len();
+            return Some(SourceInfo::original(file_id, start, end));
+        }
+        start += line.len();
+    }
+    None
 }
 
 /// Every problem found while validating a document, with the [`SourceContext`]

--- a/crates/data-dict/tests/snapshots/validate_data__nulls_in_required_column_reported.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__nulls_in_required_column_reported.snap
@@ -19,7 +19,7 @@ Error: [D01] A required column must not contain nulls.
   4 │   t:
     │ 
   8 │       - name: weight
-    │ 
+  9 │         type: number(quantity)
  10 │         constraints: [required]
     │                       ────┬───  
     │                           ╰───── has 1 null value

--- a/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_does_not_stop_other_tables.snap
+++ b/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_does_not_stop_other_tables.snap
@@ -26,7 +26,7 @@ Error: [M05] A table's `source` must point at a readable Parquet file.
    ╭─[ dict.yaml:6:16 ]
    │
  4 │   animals:
-   │ 
+ 5 │     source:
  6 │       parquet: missing.parquet
    │                ───────┬───────  
    │                       ╰───────── Parquet error: Cannot open file: No such file or directory (os error 2)

--- a/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_reported.snap
+++ b/crates/data-dict/tests/snapshots/validate_meta__unreadable_source_reported.snap
@@ -16,7 +16,7 @@ Error: [M05] A table's `source` must point at a readable Parquet file.
    ╭─[ dict.yaml:6:16 ]
    │
  4 │   animals:
-   │ 
+ 5 │     source:
  6 │       parquet: missing.parquet
    │                ───────┬───────  
    │                       ╰───────── Parquet error: Cannot open file: No such file or directory (os error 2)

--- a/crates/data-dict/tests/snapshots/validate_spec__s01_fk_no_relationship.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s01_fk_no_relationship.snap
@@ -33,7 +33,7 @@ Error: [S01] Every `foreign_key` column must have a matching relationship to a `
   9 │   food:
     │ 
  15 │       - name: food_category_id
-    │ 
+ 16 │         type: number(id)
  17 │         constraints: [foreign_key]
     │                       ─────┬─────  
     │                            ╰─────── is `foreign_key` but no relationship points it at a `primary_key`

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_enum_without_values.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_enum_without_values.snap
@@ -13,7 +13,7 @@ Error: [S07] An `enum` column must list its categories with `values`.
    ╭─[ dict.yaml:7:15 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: c
  7 │         type: enum
    │               ──┬─  

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_examples_on_boolean.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_examples_on_boolean.snap
@@ -14,9 +14,9 @@ Error: [S07] A `boolean` column must not have `values`, `range`, or `examples`.
    ╭─[ dict.yaml:8:19 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: active
-   │ 
+ 7 │         type: boolean
  8 │         examples: [true, false]
    │                   ──────┬─────  
    │                         ╰─────── has type `boolean` but uses `examples`

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_other_type_missing_examples.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_other_type_missing_examples.snap
@@ -15,7 +15,7 @@ Error: [S07] A `string` column must describe its data with `examples`.
    ╭─[ dict.yaml:7:15 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: label
  7 │         type: string
    │               ───┬──  

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_range_on_string_type.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_range_on_string_type.snap
@@ -15,7 +15,7 @@ Error: [S07] A `string` column must not use `range`.
    ╭─[ dict.yaml:9:16 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: c
    │ 
  9 │         range: ["a", "z"]

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_range_type_missing_range.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_range_type_missing_range.snap
@@ -15,7 +15,7 @@ Error: [S07] A `number(quantity)` column must describe its bounds with `range`.
    ╭─[ dict.yaml:7:15 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: weight
  7 │         type: number(quantity)
    │               ────────┬───────  

--- a/crates/data-dict/tests/snapshots/validate_spec__s07_wrong_rep_on_enum.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s07_wrong_rep_on_enum.snap
@@ -14,7 +14,7 @@ Error: [S07] An `enum` column must list its categories with `values`.
    ╭─[ dict.yaml:7:15 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: status
  7 │         type: enum
    │               ──┬─  
@@ -25,9 +25,9 @@ Error: [S07] An `enum` column must use `values`, not `range`.
    ╭─[ dict.yaml:8:16 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: status
-   │ 
+ 7 │         type: enum
  8 │         range: [0, 10]
    │                ───┬──  
    │                   ╰──── has type `enum` but uses `range`

--- a/crates/data-dict/tests/snapshots/validate_spec__s08_units_on_non_quantity.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s08_units_on_non_quantity.snap
@@ -15,9 +15,9 @@ Error: [S08] A column with `units` must have type `number(quantity)`.
    ╭─[ dict.yaml:8:16 ]
    │
  4 │   races:
-   │ 
+ 5 │     columns:
  6 │       - name: finish_rank
-   │ 
+ 7 │         type: number(ordinal)
  8 │         units: place
    │                ──┬──  
    │                  ╰──── has `units` but has type `number(ordinal)`

--- a/crates/data-dict/tests/snapshots/validate_spec__s11_empty_column_name.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s11_empty_column_name.snap
@@ -14,7 +14,7 @@ Error: [S11] Every column must have a non-empty `name`.
    ╭─[ dict.yaml:6:15 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: ""
    │               │ 
    │               ╰─ the `name` is empty

--- a/crates/data-dict/tests/snapshots/validate_spec__s12_date_not_iso.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s12_date_not_iso.snap
@@ -14,9 +14,9 @@ Error: [S12] Each `range` value of a `date` column must be an ISO 8601 date (YYY
    ╭─[ dict.yaml:8:31 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: seen_on
-   │ 
+ 7 │         type: date
  8 │         range: ["2020-01-01", "20-01-2021"]
    │                               ─────┬────  
    │                                    ╰────── is a string

--- a/crates/data-dict/tests/snapshots/validate_spec__s12_wrong_value_type.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s12_wrong_value_type.snap
@@ -14,9 +14,9 @@ Error: [S12] Each `examples` value of a `number` column must be a number.
    ╭─[ dict.yaml:8:23 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: count
-   │ 
+ 7 │         type: number
  8 │         examples: [1, two, 3]
    │                       ─┬─  
    │                        ╰─── is a string

--- a/crates/data-dict/tests/snapshots/validate_spec__s13_descending_range.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s13_descending_range.snap
@@ -15,7 +15,7 @@ Error: [S13] A range's minimum must be less than or equal to its maximum.
    ╭─[ dict.yaml:9:17 ]
    │
  4 │   table:
-   │ 
+ 5 │     columns:
  6 │       - name: mass
    │ 
  9 │         range: [100, 10]

--- a/crates/data-dict/tests/snapshots/validate_spec__s14_time_zone_on_non_datetime.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s14_time_zone_on_non_datetime.snap
@@ -15,7 +15,7 @@ Error: [S14] A column with `time_zone` must have type `datetime`.
    ╭─[ dict.yaml:8:20 ]
    │
  4 │   events:
-   │ 
+ 5 │     columns:
  6 │       - name: event_day
  7 │         type: date
  8 │         time_zone: America/New_York

--- a/crates/data-dict/tests/snapshots/validate_spec__s15_bad_time_zone.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s15_bad_time_zone.snap
@@ -15,7 +15,7 @@ Error: [S15] A `time_zone` must be `naive`, `UTC`, or an IANA `Area/Location` na
    ╭─[ dict.yaml:8:20 ]
    │
  4 │   events:
-   │ 
+ 5 │     columns:
  6 │       - name: observed_at
  7 │         type: datetime
  8 │         time_zone: PST

--- a/crates/data-dict/tests/snapshots/validate_spec__warn_single_table_description.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__warn_single_table_description.snap
@@ -25,7 +25,7 @@ Warning: [S16] A single-table dictionary's description and details belong at the
    ╭─[ dict.yaml:6:5 ]
    │
  4 │   food:
-   │ 
+ 5 │     description: Each row is a food item.
  6 │     details: Collected from the USDA FoodData Central database.
    │     ───┬───  
    │        ╰───── table `food` has a `details`


### PR DESCRIPTION
When a diagnostic's rendered source lines (its faded context spans plus its primary span) were separated by exactly one line, the renderer elided that line to a blank separator — which costs the same vertical space as showing it, while telling the reader less.

`render_with_source` now synthesizes a faded span for any single-line gap between rendered lines, so contiguous context reads clearly. Gaps of more than one line are still elided.

Before:
```
 4 │   animals:
   │ 
 6 │       parquet: missing.parquet
   │                ───────┬───────
   │                       ╰───────── Parquet error: ...
```

After:
```
 4 │   animals:
 5 │     source:
 6 │       parquet: missing.parquet
   │                ───────┬───────
   │                       ╰───────── Parquet error: ...
```

Behavior is locked in by the regenerated snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)